### PR TITLE
Fix filters for Explore Page

### DIFF
--- a/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -119,9 +119,9 @@ function DocCategoryGeneratedIndexPageContent({ categoryGeneratedIndex }: Props)
 
             return (
                 (selectedPartners.length === 0 ||
-                    selectedPartners.some((partner) => categoryIndex.includes(partner.value))) &&
+                    selectedPartners.every((partner) => categoryIndex.includes(partner.value))) &&
                 (selectedTechDomains.length === 0 ||
-                    selectedTechDomains.some((domain) => categoryIndex.includes(domain.value)))
+                    selectedTechDomains.every((domain) => categoryIndex.includes(domain.value)))
             );
         });
     }, [isExplorePage, isResetEnabled, preFilteredItems, selectedPartners, selectedTechDomains]);


### PR DESCRIPTION
## What reference architecture does this PR apply to?
NA

## Who should review your contribution? (Use @mention)
@cernus76 

## Explanation of the fix
- Instead of some(), which allows a match to any of the selected values (OR logic), I now use every(), ensuring that all selected filters must match for an item to be included.
- Now, an item will only appear in the list if it belongs to every selected partner and every selected tech domain.
