### PR TITLE
Move Links on svgs to create space for the QRCodes

### DIFF
--- a/src/_scripts/_export-drawios.js
+++ b/src/_scripts/_export-drawios.js
@@ -149,7 +149,7 @@ for (const [drawioPath, svgPath] of Object.entries(transforms)) {
                     <g transform="translate(0, ${logo.y})">
                         <image width="${logo.w}" height="${logo.h}" href="data:image/svg+xml;base64,${Buffer.from(logoSvg).toString('base64')}" />
                     </g>
-                    <text x="${width / 2}" y="${logo.y + Math.round(logo.h * 0.75)}" font-family="Arial"
+                    <text x="${width / 2 - pad}" y="${logo.y + Math.round(logo.h * 0.75)}" font-family="Arial"
                             font-size="${Math.round(18 * scaleDown)}">
                         ${URL + slug}
                     </text>


### PR DESCRIPTION
The QRCodes aren't implemented on the most recent Version of the dev branch. 
The distance between links and QRCodes has been tested on another Version: [https://github.com/SAP/architecture-center/pull/201](url). 
I dont think the slight shift of the links to the left looks bad, PO should decide if it's okay though. :)

## Who should review your contribution? (Use @mention)
@julian-schambeck @cernus76 

