### PR TITLE
Fix: On refresh Domain/Partner filters lose dark mode

### DIFF
--- a/src/theme/DocCategoryGeneratedIndexPage/index.tsx
+++ b/src/theme/DocCategoryGeneratedIndexPage/index.tsx
@@ -73,16 +73,15 @@ function getSelectStyles(isDarkMode: boolean): StylesConfig<{ value: string; lab
 
 function DocCategoryGeneratedIndexPageContent({ categoryGeneratedIndex }: Props): JSX.Element {
     const { colorMode } = useColorMode();
-    const [isDarkMode, setIsDarkMode] = useState<boolean>(colorMode === 'dark');
-
-    useEffect(() => {
-        setIsDarkMode(colorMode === 'dark');
-    }, [colorMode]);
 
     const category = useCurrentSidebarCategory();
     const isExplorePage = category?.customProps?.id === 'exploreallrefarch';
 
-    const selectStyles = useMemo(() => getSelectStyles(isDarkMode), [isDarkMode]);
+    const [selectStyles, setSelectStyles] = useState<StylesConfig<{ value: string; label: string }, true>>();
+
+    useEffect(() => {
+        setSelectStyles(getSelectStyles(colorMode === "dark"));
+    }, [colorMode]);
 
     const categories = useMemo(
         () =>
@@ -160,7 +159,7 @@ function DocCategoryGeneratedIndexPageContent({ categoryGeneratedIndex }: Props)
                 </header>
 
                 <div className={styles.contentWrapper}>
-                    {isExplorePage && (
+                    {isExplorePage && selectStyles && ( // switch from Select's default style to ours causes visual flash, prevent this
                         <aside className={styles.filters}>
                             <div className={styles.filterRow}>
                                 <div className={styles.filterGroup}>


### PR DESCRIPTION
closes #222 

This refers to the filters on the Card-Style Overview. See #222

## What reference architecture does this PR apply to?

## Who should review your contribution? (Use @mention)
@navyakhurana 

## Checklist before submitting
- [ ] My commits are only for the reference architecture mentioned above.
- [ ] I have followed the folder structure in the [main README](../README.md)
