### PR TITLE
Fix/209 png to clipboard

### DIFF
--- a/src/components/DrawioResources.jsx
+++ b/src/components/DrawioResources.jsx
@@ -77,7 +77,7 @@ export default function DrawioResources({ drawioFile, drawioXml, drawioImg }) {
                         <Button
                             design="Transparent"
                             icon={`sap-icon://${icon}`}
-                            tooltip="Copy Reference Architecture to clipboard"
+                            tooltip="Copy Solution Diagram to Clipboard"
                             style={{ position: 'absolute', top: -15, right: 0, width: 30 }}
                         ></Button>
                     </a>


### PR DESCRIPTION
Implemented a workaround where we copy a png of the Reference Architectures to the user's clipboard.
Currently, users get a feedback from the changing icon on the copy button when clicking it. 

We could also use a toast to give feedback but the current option seemed a bit more elegant.

@julian-schambeck @cernus76 

#209 
