### PR TITLE
[BUG] Update page title and metadata for Home component

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,42 +1,9 @@
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import Heading from '@theme/Heading';
-import ThemedImage from '@theme/ThemedImage';
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
-import styles from './index.module.css';
 import React, { JSX } from 'react';
 import HeroSection from '../sections/HeroSection';
 import CommunitySection from '../sections/Community';
 import ExploreArchitectureSection from '../sections/ExploreArchitectureSection';
-
-function HomepageHeader() {
-    const { siteConfig } = useDocusaurusContext();
-    return (
-        <header className={clsx('hero hero--primary', styles.heroBanner)}>
-            <div className="container">
-                <Heading as="h1" className="header_text">
-                    {siteConfig.title}
-                </Heading>
-                <ThemedImage
-                    alt="SAP Architecture Center"
-                    sources={{
-                        light: useBaseUrl('img/btp-Spot-Tools.png'),
-                        dark: useBaseUrl('img/btp-Spot-Tools.png'),
-                    }}
-                />
-                <p className="hero_body">{siteConfig.tagline}</p>
-                <div className={styles.buttons}>
-                    <Link className="button button--secondary button--lg" color="blue" to="/docs/intro">
-                        Start now 🚀
-                    </Link>
-                </div>
-            </div>
-        </header>
-    );
-}
 
 export default function Home(): JSX.Element {
     const { siteConfig } = useDocusaurusContext();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,15 +42,15 @@ export default function Home(): JSX.Element {
     const { siteConfig } = useDocusaurusContext();
     return (
         <Layout
-            title={siteConfig.title}
+            title='Create reference architectures'
             description={siteConfig.tagline}
             metadata={[
-                { property: 'og:title', content: siteConfig.title },
+                { property: 'og:title', content: 'Create reference architectures' },
                 { property: 'og:description', content: siteConfig.tagline },
                 { property: 'og:type', content: 'website' },
                 { property: 'og:url', content: 'https://architecture.learning.sap.com/' },
                 { name: 'twitter:card', content: 'summary_large_image' },
-                { name: 'twitter:title', content: siteConfig.title },
+                { name: 'twitter:title', content: 'Create reference architectures' },
                 { name: 'twitter:description', content: siteConfig.tagline },
             ]}
         >


### PR DESCRIPTION
## What reference architecture does this PR apply to?
Landing page. When I added the meta tags, I didn't realize that **every** page gets the '| SAP Architecture Center' added to it. This comes from our [site config](https://docusaurus.io/docs/configuration#site-metadata)

I implemented the landing page head tags in src/pages/index.tsx L45-55:

```
title='Create reference architectures'
            description={siteConfig.tagline}
            metadata={[
                { property: 'og:title', content: 'Create reference architectures' },
                { property: 'og:description', content: siteConfig.tagline },
                { property: 'og:type', content: 'website' },
                { property: 'og:url', content: 'https://architecture.learning.sap.com/' },
                { name: 'twitter:card', content: 'summary_large_image' },
                { name: 'twitter:title', content: 'Create reference architectures' },
                { name: 'twitter:description', content: siteConfig.tagline },
            ]}
```

But previously, I was setting it to {siteConfig.title}, not realizing that it would result in duplication. So, this is ready for review, and if you're ok with a final title of:

Create reference architectures | SAP Architecture Center

You can merge as-is. If you have a shorter or fancier proposal, just add another commit to this PR. For reference, SAP Learning Center's landing page is:

Learn SAP skills | SAP Learning

SAP.com is:

SAP Software Solutions | Business and Technology
  
## Who should review your contribution? (Use @mention)
@cernus76 this one is for you

## Checklist before submitting
- [x] My commits are only for the reference architecture mentioned above.
- [x] I have followed the folder structure in the [main README](../README.md)
