### PR TITLE
footerfix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,12 @@
-[*.ts]
-indent_style = space
-indent_size = 4
+root = true
+
+[*]
+
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{ts,js,tsx,jsx}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.ts]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/community/Guidelines/contribution.md
+++ b/community/Guidelines/contribution.md
@@ -83,3 +83,7 @@ gitGraph
 :::tip Best Practice
 Regularly sync with the main repository before contributing or creating a pull request to avoid merge conflicts.
 :::
+
+## Formatting Consistency
+
+To ensure consistent code and documentation formatting across all contributions, we use [Prettier](https://prettier.io/docs/configuration) for automatic code formatting. Additionally, we provide a [.editorconfig](https://learn.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022) file to standardize basic editor settings (such as indentation and line endings) across different IDEs. Please make sure your editor respects these settings for a smooth collaboration experience.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,7 +7,8 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
     title: 'SAP Architecture Center',
-    tagline: 'SAP Architecture Center empowers architects and developers with best practices, reference architectures, and community-driven guidance for designing, integrating, and optimizing SAP and cloud solutions. Accelerate innovation, ensure security, and reduce costs with proven frameworks and collaborative expertise for enterprise transformation.',
+    tagline:
+        'SAP Architecture Center empowers architects and developers with best practices, reference architectures, and community-driven guidance for designing, integrating, and optimizing SAP and cloud solutions. Accelerate innovation, ensure security, and reduce costs with proven frameworks and collaborative expertise for enterprise transformation.',
     favicon: 'img/logo.svg',
 
     url: 'https://architecture.learning.sap.com',
@@ -181,72 +182,72 @@ const config: Config = {
                     items: [
                         {
                             type: 'html',
-                            value: '<strong>Architecture Explorer</strong>'
+                            value: '<strong>Architecture Explorer</strong>',
                         },
                         {
                             to: '/docs/exploreallrefarch',
-                            label: 'Card-Style Overview'
+                            label: 'Card-Style Overview',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'refarchSidebar',
-                            label: 'Navigator-Style Overview'
+                            label: 'Navigator-Style Overview',
                         },
                         {
                             type: 'html',
-                            value: '<hr style="margin: 0.3rem 0;">'
+                            value: '<hr style="margin: 0.3rem 0;">',
                         },
                         {
                             type: 'html',
-                            value: '<strong>Technology Domains</strong>'
+                            value: '<strong>Technology Domains</strong>',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'appdev',
-                            label: 'Application Development & Automation'
+                            label: 'Application Development & Automation',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'ai',
-                            label: 'Artificial Intelligence'
+                            label: 'Artificial Intelligence',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'data',
-                            label: 'Data & Analytics'
+                            label: 'Data & Analytics',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'integration',
-                            label: 'Integration'
+                            label: 'Integration',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'opsec',
-                            label: 'Operation & Security'
+                            label: 'Operation & Security',
                         },
                         {
                             type: 'html',
-                            value: '<hr style="margin: 0.3rem 0;">'
+                            value: '<hr style="margin: 0.3rem 0;">',
                         },
                         {
                             type: 'html',
-                            value: '<strong>Technology Partners</strong>'
+                            value: '<strong>Technology Partners</strong>',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'aws',
-                            label: 'Amazon Web Services'
+                            label: 'Amazon Web Services',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'azure',
-                            label: 'Microsoft Azure'
+                            label: 'Microsoft Azure',
                         },
                         {
                             type: 'docSidebar',
                             sidebarId: 'gcp',
-                            label: 'Google Cloud Platform'
+                            label: 'Google Cloud Platform',
                         },
                     ],
                 },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -52,13 +52,13 @@ const config: Config = {
                 docsRouteBasePath: ['/docs', '/community'],
                 docsDir: ['docs', 'community'],
                 indexBlog: true,
-                blogRouteBasePath: '/blog', 
+                blogRouteBasePath: '/blog',
                 language: ['en'],
                 highlightSearchTermsOnTargetPage: true,
                 removeDefaultStopWordFilter: true,
                 removeDefaultStemmer: true,
             },
-        ],        
+        ],
         async function tailwindcss() {
             return {
                 name: 'docusaurus-tailwindcss',
@@ -283,7 +283,7 @@ const config: Config = {
                             href: 'https://community.sap.com/t5/enterprise-architecture/gh-p/Enterprise-Architecture',
                         },
                         {
-                            label: 'Blogs',
+                            label: 'Blog Posts',
                             href: 'https://community.sap.com/t5/all-sap-community-blogs/ct-p/all-blogs',
                         },
                         {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5",
-    "printWidth": 120
+    "printWidth": 120,
+    "endOfLine": "lf" 
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This is a general minor fix, not specific to any architecture.

- add editorconfig to formalise explicit standards
- fix footer "Blogs" -> "Blog Posts"

I wanted to provide a fix for the minor footer issue, and in doing so noticed a need for a formalised explicit set of editor configuration standards, to prevent inadvertent mass-changes to lines, e.g. from 4 to 2 space indents. Therefore I added a basic `.editorconfig` file to reflect the basics of the `docusaurus.config.ts` file.

Thanks!

