### PR TITLE
Potential fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,5 +1,9 @@
 name: Build for GitHub Pages
 
+permissions:
+    contents: read
+    pages: write
+
 on:
     push:
         branches:

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -4,6 +4,10 @@ on:
     # for local PR builds esp. builds in forked repositories
     workflow_dispatch:
 
+permissions:
+    contents: read
+    pages: write
+
 jobs:
     build:
         name: Build Site

--- a/.github/workflows/find-unreferenced-files.yml
+++ b/.github/workflows/find-unreferenced-files.yml
@@ -1,5 +1,8 @@
 name: Find Unreferenced Files
 
+permissions:
+    contents: read
+
 on:
     schedule:
         - cron: '0 6 * * 1' # Every Monday at 06:00 UTC

--- a/.github/workflows/reuse-check.yml
+++ b/.github/workflows/reuse-check.yml
@@ -1,6 +1,9 @@
 name: REUSE Compliance Check
 # To manually verify/falsify reuse check results
 
+permissions:
+    contents: read
+
 on:
     workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/SAP/architecture-center/security/code-scanning/2186](https://github.com/SAP/architecture-center/security/code-scanning/2186)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for the `GITHUB_TOKEN`. Based on the workflow's actions:
- The `build` job requires `contents: read` to fetch repository contents and `pages: write` to interact with GitHub Pages.
- The `deploy` job requires `contents: read` to fetch repository contents and `pages: write` to deploy the site.

We will add a `permissions` block at the root level to apply these permissions to all jobs in the workflow.

@cernus76 @jmsrpp 
