### PR TITLE
add font-display swap to reduce CLS and improve score

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -66,21 +66,25 @@ pre {
     font-family: '72';
     src: url('../css/font/72Brand-Bold.woff2') format('woff2');
     font-weight: bold;
+    font-display: swap;
 }
 @font-face {
     font-family: '72';
     src: url('../css/font/72Brand-Black.woff2') format('woff2');
     font-weight: 900;
+    font-display: swap;
 }
 @font-face {
     font-family: '72';
     src: url('../css/font/72Brand-Medium.woff2') format('woff2');
     font-weight: 500;
+    font-display: swap;
 }
 @font-face {
     font-family: '72';
     src: url('../css/font/72Brand-Regular.woff2') format('woff2');
     font-weight: normal;
+    font-display: swap;
 }
 
 ui5-button::part(button) {


### PR DESCRIPTION
## What reference architecture does this PR apply to?
N/A as this is a site-wide change. Google reports problematic [Cumulative Layout Shift CLS](https://support.google.com/webmasters/answer/9205520?#status_explanation&zippy=%2Cwebsite-developers) on a number of our pages. The root cause is at least partially related to use of web fonts such as 72Brand. Remediation is to specify a property of font-display: swap on all usage. I have checked in a simple fix. There are further optimizations available on img containers but that would require more effort. This should be a trivial fix for the most obvious problems.

## Who should review your contribution? (Use @mention)
@navyakhurana 

## Checklist before submitting
- [x] My commits are only for the reference architecture mentioned above.
- [x] I have followed the folder structure in the [main README](../README.md)
