### PR TITLE
React hydration and DrawioResources bugs

### DIFF
--- a/src/components/DrawioResources.jsx
+++ b/src/components/DrawioResources.jsx
@@ -56,39 +56,37 @@ export default function DrawioResources({ drawioFile, drawioXml, drawioImg }) {
             });
     }
     return (
-        // current selector to apply zoom (see docusaurus.config) doesn't select img if directly
-        // under div with class 'markdown' => wrap img in paragraph for now
+        // current selector to apply zoom (see docusaurus.config) selects img as direct child
+        // using single div with inline-block display to maintain zoom functionality
         <>
-            <p>
-                <div style={{ position: 'relative', display: 'inline-block' }}>
-                    <img
-                        decoding="async"
-                        loading="lazy"
-                        src={drawioImg ?? path}
-                        alt="image of solution diagram"
-                        className={drawioImg ? '' : 'fallback-image'}
-                        style={{ height: 'auto' }}
-                    />
-                    {drawioImg && (
-                        <div class="tooltip">
-                            <IconButton
-                                onClick={() => {
-                                    setCopied(true), handleDownload();
-                                }}
-                                className="iconButton"
-                                variant="default"
-                            >
-                                {copied ? (
-                                    <CheckIcon style={{ fontSize: 20 }} />
-                                ) : (
-                                    <ContentCopyIcon style={{ fontSize: 20 }} />
-                                )}
-                            </IconButton>
-                            <span class="tooltip_text">{copied ? 'Copied!' : 'Copy to clipboard'}</span>
-                        </div>
-                    )}
-                </div>
-            </p>
+            <div style={{ position: 'relative', display: 'inline-block' }}>
+                <img
+                    decoding="async"
+                    loading="lazy"
+                    src={drawioImg ?? path}
+                    alt="image of solution diagram"
+                    className={drawioImg ? '' : 'fallback-image'}
+                    style={{ height: 'auto' }}
+                />
+                {drawioImg && (
+                    <div className="tooltip">
+                        <IconButton
+                            onClick={() => {
+                                setCopied(true), handleDownload();
+                            }}
+                            className="iconButton"
+                            variant="default"
+                        >
+                            {copied ? (
+                                <CheckIcon style={{ fontSize: 20 }} />
+                            ) : (
+                                <ContentCopyIcon style={{ fontSize: 20 }} />
+                            )}
+                        </IconButton>
+                        <span className="tooltip_text">{copied ? 'Copied!' : 'Copy to clipboard'}</span>
+                    </div>
+                )}
+            </div>
             <Admonition type="info" title="Solution Diagram Resources">
                 You can download the Solution Diagram as a{' '}
                 <b>

--- a/src/sections/ExploreArchitectureSection.tsx
+++ b/src/sections/ExploreArchitectureSection.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useMemo, useEffect } from 'react';
+// @ts-ignore
 import DocCard from '@theme/DocCard';
 // @ts-ignore
 import exploreSidebar from '../data/exploreArch.json';
@@ -21,13 +22,22 @@ export default function ExploreAllArchitecturesSection() {
         return 3;
     };
 
-    const [cardsPerGroup, setCardsPerGroup] = useState(getCardsPerGroup());
+    const [cardsPerGroup, setCardsPerGroup] = useState(3); // SSR-safe default
     const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
+    const [isHydrated, setIsHydrated] = useState(false);
 
     const carouselRef = useRef<HTMLDivElement>(null);
 
+    // Set initial cards per group after hydration
+    useEffect(() => {
+        setCardsPerGroup(getCardsPerGroup());
+        setIsHydrated(true);
+    }, []);
+
     // Recalculate cards per group on resize
     useEffect(() => {
+        if (!isHydrated) return; // Only run after hydration
+
         const handleResize = () => {
             const newGroupSize = getCardsPerGroup();
             setCardsPerGroup(newGroupSize);
@@ -36,7 +46,7 @@ export default function ExploreAllArchitecturesSection() {
 
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, []);
+    }, [isHydrated]);
 
     // Group items into chunks
     const groupedItems = useMemo(() => {
@@ -98,8 +108,8 @@ export default function ExploreAllArchitecturesSection() {
                 <div ref={carouselRef} className={styles.carouselContainer}>
                     {groupedItems.map((group, index) => (
                         <div key={index} className={styles.cardGroup}>
-                            {group.map((item) => (
-                                <div className={styles.cardContainer}>
+                            {group.map((item, itemIndex) => (
+                                <div key={item.href || itemIndex} className={styles.cardContainer}>
                                     <DocCard item={item} />
                                 </div>
                             ))}


### PR DESCRIPTION
## What reference architecture does this PR apply to?
N/A > This fix is for react hydration errors and a regression to the invalid DOM element when viewing a drawio-based svg (the zoom selector issue). You can see the errors in the browser console when navigating from the main page, to the explore all page, to any individual RA.

## Issues Fixed:

1. __Nested DOM Error__: Removed the invalid HTML structure where a `<div>` was nested inside a `<p>` element, which violates HTML standards and causes React DOM warnings.

2. __React JSX Warning__: Fixed the `class` vs `className` attribute warnings in the tooltip elements.

3. __React hydration errors (418 and 423)__: Errors were caused by a hydration mismatch in the ExploreArchitectureSection.tsx component, where window.innerWidth was being used during initial state calculation, creating different values between server-side rendering and client-side hydration.

## Solution Implemented:

- Replaced the problematic `<p><div>` nesting with a single `<div>` element that has `position: relative` and `display: inline-block` styles
- Changed all `class` attributes to `className` for proper React JSX syntax
- Changed initial state and replaced `useState(getCardsPerGroup())` with `useState(3)` for SSR-safe default
- Added hydration guard by introducing `isHydrated` state to track component hydration status
- Moved window-dependent logic by Using `useEffect` to set responsive values only after hydration
- Ensured resize event listener only runs after hydration
- Updated the code comments to reflect the new approach


## Who should review your contribution? (Use @mention)
@navyakhurana @cernus76 

## Checklist before submitting
- [x] My commits are only for the reference architecture mentioned above.
- [x] I have followed the folder structure in the [main README](../README.md)
