### PR TITLE
Adjusted the watermark size

### DIFF
--- a/src/_scripts/_export-drawios.js
+++ b/src/_scripts/_export-drawios.js
@@ -111,14 +111,14 @@ async function watermarkAll() {
         viewBox[0] = -pad;
         viewBox[1] = -pad;
         viewBox[2] = width + pad * 2;
-        const logo = { h: 52, w: 106, mt: 28 };
-        logo.y = height + logo.mt;
+        const logo = { h: 57, w: 116, mt: 36 };
         let scaleDown = width / 1500;
         scaleDown = Math.max(0.7, scaleDown);
         logo.h = logo.h * scaleDown;
         logo.w = logo.w * scaleDown;
         const yShift = 56 * scaleBox;
         viewBox[3] = height + pad * 2 + logo.mt + logo.h + yShift;
+        logo.y = viewBox[3] - pad * 2 - logo.h - yShift;
         const textX = logo.w + pad;
 
         try {
@@ -144,29 +144,29 @@ async function watermarkAll() {
             const smallSlug = slug.match(/\/ref-arch\/(\S+)/)?.[1] || '';
             const qrLink = `${BASE_URL}/docs${slug}`; // Corrected QR link
             const qrSvgContent = await generateQrSvg(qrLink);
-            const qrSize = 33 * 1.9 * scaleDown;
+            const qrSize = 33 * 2.4 * scaleDown;
 
-            const mark = `<text x="0" y="${pad}" font-family="Arial" font-weight="bold" font-size="${Math.round(22 * scaleDown)}">
+            const mark = `<text x="0" y="${pad}" font-family="Arial" font-weight="bold" font-size="${Math.round(27 * scaleDown)}">
                             <![CDATA[${title}]]>
                         </text>
                         <g transform="translate(0, ${yShift})">
-                        <text x="${textX}" y="${logo.y + Math.round(logo.h * 0.5)}" font-family="Arial" font-weight="bold"
-                                font-size="${Math.round(20 * scaleDown)}">
+                        <text x="${textX}" y="${(logo.y + Math.round(logo.h * 0.5))}" font-family="Arial" font-weight="bold"
+                                font-size="${Math.round(22 * scaleDown)}">
                             Architecture Center
                         </text>
                         <text x="${textX}" y="${logo.y + Math.round(logo.h * 0.9)}" font-family="Arial" font-style="italic"
-                                font-size="${Math.round(16 * scaleDown)}">
+                                font-size="${Math.round(17 * scaleDown)}">
                             Last update on ${lastUpdate}
                         </text>
                         <g transform="translate(0, ${logo.y})">
                             <image width="${logo.w}" height="${logo.h}" href="data:image/svg+xml;base64,${Buffer.from(logoSvg).toString('base64')}" />
                         </g>
                         <text x="${width / 2 - pad}" y="${logo.y + Math.round(logo.h * 0.75)}" font-family="Arial"
-                                font-size="${Math.round(18 * scaleDown)}">
+                                font-size="${Math.round(20 * scaleDown)}">
                             ${smallSlug}
                         </text>
                         </g>
-                        <g transform="translate(${width - qrSize}, ${viewBox[3] - pad * 2 - qrSize}) scale(${1.9 * scaleDown})">
+                        <g transform="translate(${width - qrSize}, ${viewBox[3] - pad * 2 - qrSize}) scale(${2.4 * scaleDown})">
                             ${qrSvgContent}
                         </g>`;
 


### PR DESCRIPTION
I tried my best do adjust the watermark size without making any unnecessary changes. The only remarkable change I did, was changin the calculation of logo.y. I did this to ensure we always have enough padding to the bottom of the svgs when increasing the logo's size. 
I used the same calculation for our Qr Code before, so it's easier to understand now.

## What reference architecture does this PR apply to?
All 

## Who should review your contribution? (Use @mention)
 @cernus76 


