### PR TITLE
Minor CSS fix for doc cards + React crousel responsive fix

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -69,9 +69,9 @@
     --button-width-standard: 150px;
 
     /* Custom card dimensions */
-    --card-height-desktop: 290px;
-    --card-height-tablet: 340px;
-    --card-height-mobile: 360px;
+    --card-height-desktop: 300px;
+    --card-height-tablet: 300px;
+    --card-height-mobile: 320px;
     --card-max-width: 430px;
     --card-max-width-tablet: 600px;
 
@@ -1090,6 +1090,7 @@ html[data-footer='false'] .footer {
 
     .slick-dots {
         margin-bottom: 1rem !important;
+        margin-top: 1rem !important;
     }
 
     .community_image {
@@ -1135,6 +1136,7 @@ html[data-footer='false'] .footer {
     }
 
     .slick-dots {
-        margin-bottom: 0.5rem !important;
+        margin-bottom: 1rem !important;
+        margin-top: 1rem !important;
     }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -69,9 +69,9 @@
     --button-width-standard: 150px;
 
     /* Custom card dimensions */
-    --card-height-desktop: 300px;
-    --card-height-tablet: 300px;
-    --card-height-mobile: 320px;
+    --card-height-desktop: 290px;
+    --card-height-tablet: 340px;
+    --card-height-mobile: 360px;
     --card-max-width: 430px;
     --card-max-width-tablet: 600px;
 

--- a/src/sections/ExploreArchitectureSection.tsx
+++ b/src/sections/ExploreArchitectureSection.tsx
@@ -16,7 +16,7 @@ export default function ExploreAllArchitecturesSection() {
     const settings = {
         dots: true,
         arrows: false, // We'll use our own UI5 buttons for navigation
-        infinite: items.length > 3,
+        infinite: false, // Disable infinite scrolling
         speed: 500,
         slidesToShow: 3,
         slidesToScroll: 1,
@@ -26,6 +26,7 @@ export default function ExploreAllArchitecturesSection() {
                 settings: {
                     slidesToShow: 1,
                     slidesToScroll: 1,
+                    infinite: false, // Ensure infinite is disabled on mobile too
                 },
             },
         ],

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -7,124 +7,128 @@ html[data-theme='dark'] .tag:hover {
 }
 
 .docCard {
-  height: var(--card-height-desktop);
-  cursor: pointer;
-  border-radius: var(--border-radius-lg);
-  overflow: visible;
-  transition: all 0.3s ease-in-out;
-  background-color: var(--ifm-card-background);
-  box-shadow: var(--shadow-card);
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+    height: var(--card-height-desktop);
+    cursor: pointer;
+    border-radius: var(--border-radius-lg);
+    overflow: visible;
+    transition: all 0.3s ease-in-out;
+    background-color: var(--ifm-card-background);
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    margin-top: 5px;
 }
 
 .docCard:hover {
-  background-color: var(--ifm-hover-overlay);
-  box-shadow: var(--shadow-card-hover);
-  transform: translateY(-3px);
+    background-color: var(--ifm-hover-overlay);
+    box-shadow: var(--shadow-card-hover);
+    transform: translateY(-5px);
 }
 
 .cardBanner {
-  width: 100%;
-  height: 50px;
-  object-fit: cover;
-  display: block;
-  border-top-left-radius: var(--border-radius-lg);
-  border-top-right-radius: var(--border-radius-lg);
+    width: 100%;
+    height: 50px;
+    object-fit: cover;
+    display: block;
+    border-top-left-radius: var(--border-radius-lg);
+    border-top-right-radius: var(--border-radius-lg);
 }
 
 .cardAccent {
-  height: 40px;
-  width: 6px;
-  min-width: 6px;
-  border-top-right-radius: var(--spacing-xs);
-  border-bottom-right-radius: var(--spacing-xs);
-  background-color: var(--ifm-color-primary);
-  margin-top: var(--spacing-sm);
+    height: 40px;
+    width: 6px;
+    min-width: 6px;
+    border-top-right-radius: var(--spacing-xs);
+    border-bottom-right-radius: var(--spacing-xs);
+    background-color: var(--ifm-color-primary);
+    margin-top: var(--spacing-sm);
 }
 
 .cardTitle {
-  padding: 0 16px;
-  padding-top: 10px;
-  cursor: pointer;
-  font-size: 18px;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    padding: 0 16px;
+    padding-top: 10px;
+    cursor: pointer;
+    font-size: 18px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .cardDescription {
-  padding: 16px 16px 0px 16px;
-  text-align: left;
-  cursor: pointer;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    padding: 16px 16px 0px 16px;
+    text-align: left;
+    cursor: pointer;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .tagsContainer {
-  width: 100%;
-  height: 65px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 10px;
+    width: 100%;
+    height: 65px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
 }
 
 .tagsRow {
-  padding: 0 16px 0px 16px;
-  margin: 0;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  gap: 3px;
-  align-items: flex-end;
-  justify-content: flex-start;
+    padding: 0 16px 0px 16px;
+    margin: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    gap: 3px;
+    align-items: flex-end;
+    justify-content: flex-start;
+    flex-wrap: wrap;
 }
 
 .tag {
-  border-radius: var(--border-radius-sm);
-  white-space: nowrap;
+    border-radius: var(--border-radius-sm);
+    white-space: nowrap;
 }
 
 .lastUpdateRow {
-  padding: 0px 16px 10px 16px;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  justify-content: space-between;
+    padding: 0px 16px 10px 16px;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
 }
 
 .lastUpdateText {
-  cursor: pointer;
-  color: gray;
-  font-size: var(--sapFontSmallSize);
-  padding-right: 3px;
-  font-style: italic;
+    cursor: pointer;
+    color: gray;
+    font-size: var(--sapFontSmallSize);
+    padding-right: 3px;
+    font-style: italic;
 }
 
 .openInNew {
-  cursor: pointer;
-  padding-bottom: 2px;
+    cursor: pointer;
+    padding-bottom: 2px;
 }
 
 /* Tablet and Mobile styles */
 @media (max-width: 996px) {
-  .docCard {
-    height: var(--card-height-tablet);
-  }
+    .docCard {
+        height: var(--card-height-tablet);
+        margin-bottom: 20px;
+    }
 }
 
 /* Small mobile styles */
 @media (max-width: 430px) {
-  .docCard {
-    height: var(--card-height-mobile);
-  }
+    .docCard {
+        height: var(--card-height-mobile);
+        margin-bottom: 20px;
+    }
 }

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -10,7 +10,7 @@ html[data-theme='dark'] .tag:hover {
   height: var(--card-height-desktop);
   cursor: pointer;
   border-radius: var(--border-radius-lg);
-  overflow: visible;
+  overflow: hidden;
   transition: all 0.3s ease-in-out;
   background-color: var(--ifm-card-background);
   box-shadow: var(--shadow-card);

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -7,128 +7,128 @@ html[data-theme='dark'] .tag:hover {
 }
 
 .docCard {
-    height: var(--card-height-desktop);
-    cursor: pointer;
-    border-radius: var(--border-radius-lg);
-    overflow: visible;
-    transition: all 0.3s ease-in-out;
-    background-color: var(--ifm-card-background);
-    box-shadow: var(--shadow-card);
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    margin-top: 5px;
+  height: var(--card-height-desktop);
+  cursor: pointer;
+  border-radius: var(--border-radius-lg);
+  overflow: visible;
+  transition: all 0.3s ease-in-out;
+  background-color: var(--ifm-card-background);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  margin-top: 5px;
 }
 
 .docCard:hover {
-    background-color: var(--ifm-hover-overlay);
-    box-shadow: var(--shadow-card-hover);
-    transform: translateY(-5px);
+  background-color: var(--ifm-hover-overlay);
+  box-shadow: var(--shadow-card-hover);
+  transform: translateY(-5px);
 }
 
 .cardBanner {
-    width: 100%;
-    height: 50px;
-    object-fit: cover;
-    display: block;
-    border-top-left-radius: var(--border-radius-lg);
-    border-top-right-radius: var(--border-radius-lg);
+  width: 100%;
+  height: 50px;
+  object-fit: cover;
+  display: block;
+  border-top-left-radius: var(--border-radius-lg);
+  border-top-right-radius: var(--border-radius-lg);
 }
 
 .cardAccent {
-    height: 40px;
-    width: 6px;
-    min-width: 6px;
-    border-top-right-radius: var(--spacing-xs);
-    border-bottom-right-radius: var(--spacing-xs);
-    background-color: var(--ifm-color-primary);
-    margin-top: var(--spacing-sm);
+  height: 40px;
+  width: 6px;
+  min-width: 6px;
+  border-top-right-radius: var(--spacing-xs);
+  border-bottom-right-radius: var(--spacing-xs);
+  background-color: var(--ifm-color-primary);
+  margin-top: var(--spacing-sm);
 }
 
 .cardTitle {
-    padding: 0 16px;
-    padding-top: 10px;
-    cursor: pointer;
-    font-size: 18px;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  padding: 0 16px;
+  padding-top: 10px;
+  cursor: pointer;
+  font-size: 18px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .cardDescription {
-    padding: 16px 16px 0px 16px;
-    text-align: left;
-    cursor: pointer;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  padding: 16px 16px 0px 16px;
+  text-align: left;
+  cursor: pointer;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tagsContainer {
-    width: 100%;
-    height: 65px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 10px;
+  width: 100%;
+  height: 65px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
 }
 
 .tagsRow {
-    padding: 0 16px 0px 16px;
-    margin: 0;
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    gap: 3px;
-    align-items: flex-end;
-    justify-content: flex-start;
-    flex-wrap: wrap;
+  padding: 0 16px 0px 16px;
+  margin: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 3px;
+  align-items: flex-end;
+  justify-content: flex-start;
+  flex-wrap: wrap;
 }
 
 .tag {
-    border-radius: var(--border-radius-sm);
-    white-space: nowrap;
+  border-radius: var(--border-radius-sm);
+  white-space: nowrap;
 }
 
 .lastUpdateRow {
-    padding: 0px 16px 10px 16px;
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: space-between;
+  padding: 0px 16px 10px 16px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
 }
 
 .lastUpdateText {
-    cursor: pointer;
-    color: gray;
-    font-size: var(--sapFontSmallSize);
-    padding-right: 3px;
-    font-style: italic;
+  cursor: pointer;
+  color: gray;
+  font-size: var(--sapFontSmallSize);
+  padding-right: 3px;
+  font-style: italic;
 }
 
 .openInNew {
-    cursor: pointer;
-    padding-bottom: 2px;
+  cursor: pointer;
+  padding-bottom: 2px;
 }
 
 /* Tablet and Mobile styles */
 @media (max-width: 996px) {
-    .docCard {
-        height: var(--card-height-tablet);
-        margin-bottom: 20px;
-    }
+  .docCard {
+    height: var(--card-height-tablet);
+    margin-bottom: 20px;
+  }
 }
 
 /* Small mobile styles */
 @media (max-width: 430px) {
-    .docCard {
-        height: var(--card-height-mobile);
-        margin-bottom: 20px;
-    }
+  .docCard {
+    height: var(--card-height-mobile);
+    margin-bottom: 20px;
+  }
 }


### PR DESCRIPTION
## Who should review your contribution? (Use @mention)
@cernus76 @johannagonnzdz 

1. __Mobile cards__: Now display properly with better spacing and readability

2. __Carousel dots__: Properly spaced for touch interaction on all screen sizes

3. __Carousel navigation__:

   - __Desktop__: Shows 3 cards, next button works through all slides until the last 3 are visible
   - __Mobile__: Shows 1 card, next button works through all slides until the last card is visible
   - __No infinite scrolling__: Buttons properly disable at start/end positions

4. __Responsive behavior__: Navigation buttons now correctly account for the responsive `slidesToShow` changes

The carousel will now work correctly on both desktop (3 slides visible) and mobile (1 slide visible) with proper button disable logic for non-infinite scrolling.
