### PR TITLE
fix: remove requirement to deploy specific models in SAP AI Core for cline

### DIFF
--- a/docs/ref-arch/RA0005/10-vibe-code-with-cline/readme.md
+++ b/docs/ref-arch/RA0005/10-vibe-code-with-cline/readme.md
@@ -67,7 +67,7 @@ Once you have your SAP AI Core service key, you need to configure the following 
 4.  **AI Core Base URL**: The `AI_API_URL` from your service key.
 5.  **AI Core Auth URL**: The `url` from your service key.
 6.  **AI Core Resource Group**: The resource group you want to use.
-7.  **Model**: The model you want to use (e.g., `anthropic--claude-4-sonnet`, `gemini-2.5-pro`, `gpt-4.1`). You must have a [deployment](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/create-deployment-for-generative-ai-model-in-sap-ai-core) for this model in SAP AI Core.
+7.  **Model**: The model you want to use (e.g., `anthropic--claude-4-sonnet`, `gemini-2.5-pro`, `gpt-4.1`).
 
 With these settings configured, you are ready to start vibe coding with Cline and SAP AI Core.
 :::


### PR DESCRIPTION
Starting with version 3.28.0 (to be released soon), Cline supports orchestration mode, making it unnecessary to deploy models as suggested in the current Cline configuration with SAP AI Core. This is enabled by the [Harmonized API feature of orchestration](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/harmonized-api)

## What reference architecture does this PR apply to?
RA0005 - Vibe Coding with Cline and SAP AI Core

## Who should review your contribution? (Use @mention)


## Checklist before submitting
- [x] My commits are only for the reference architecture mentioned above.
- [x] I have followed the folder structure in the [main README](../README.md)
