### PR TITLE
Fixes double line logos and filters bug

### DIFF
--- a/src/sections/TrustedTecPartnersSection.tsx
+++ b/src/sections/TrustedTecPartnersSection.tsx
@@ -140,11 +140,11 @@ export default function TrustedTecPartnersSection(): JSX.Element {
               },
               {
                 breakpoint: 1024, // iPad portrait
-                settings: { slidesToShow: 4 }
+                settings: { slidesToShow: 3 }
               },
               {
                 breakpoint: 768, // smaller tablets
-                settings: { slidesToShow: 3 }
+                settings: { slidesToShow: 2 }
               },
               {
                 breakpoint: 600, // mobile -> already handled by logoList

--- a/src/store/sidebar-store.ts
+++ b/src/store/sidebar-store.ts
@@ -1,15 +1,21 @@
 import { create } from 'zustand';
 
-export const useSidebarFilterStore = create((set) => ({
-  // Technology domains
-  techDomains: [] as string[],
-  setTechDomains: (techDomains: string[]) => set({ techDomains }),
+interface SidebarFilterState {
+  techDomains: string[];
+  setTechDomains: (techDomains: string[]) => void;
 
-  // Technology partners
-  partners: [] as string[],
-  setPartners: (partners: string[]) => set({ partners }),
+  partners: string[];
+  setPartners: (partners: string[]) => void;
 
-  // Reset all filters
+  resetFilters: () => void;
+}
+
+export const useSidebarFilterStore = create<SidebarFilterState>((set) => ({
+  techDomains: [],
+  setTechDomains: (techDomains) => set({ techDomains }),
+
+  partners: [],
+  setPartners: (partners) => set({ partners }),
+
   resetFilters: () => set({ techDomains: [], partners: [] }),
 }));
-

--- a/src/theme/DocSidebar/index.tsx
+++ b/src/theme/DocSidebar/index.tsx
@@ -8,6 +8,7 @@ import styles from './styles.module.css';
 import { useSidebarFilterStore } from '@site/src/store/sidebar-store';
 import useGlobalData from '@docusaurus/useGlobalData';
 import tagsMap from '@site/src/constant/tagsMapping.json';
+import { useHistory } from '@docusaurus/router';
 
 const categoryIdToTags = Object.entries(tagsMap).reduce((acc, [tagKey, meta]) => {
   const cat = meta?.categoryid;
@@ -174,23 +175,39 @@ const DocSidebarDesktopMemo = React.memo(DocSidebarDesktop);
 const DocSidebarMobileMemo = React.memo(DocSidebarMobile);
 
 export default function DocSidebarWrapper(props) {
-    const windowSize = useWindowSize();
-    const sidebarContext = useDocsSidebar();
-    const shouldShowFilters = sidebarContext?.name === 'refarchSidebar';
+  const windowSize = useWindowSize();
+  const sidebarContext = useDocsSidebar();
+  const shouldShowFilters = sidebarContext?.name === 'refarchSidebar';
+  const resetFilters = useSidebarFilterStore((state) => state.resetFilters);
+  const history = useHistory();
 
-    const shouldRenderSidebarDesktop = windowSize === 'desktop' || windowSize === 'ssr';
-    const shouldRenderSidebarMobile = windowSize === 'mobile';
+  useEffect(() => {
+    // Subscribe to history changes
+    return history.listen((location) => {
+      console.log("Route changed:", location.pathname);
 
-    useEffect(() => {
-        if (typeof document !== 'undefined') {
-            document.body.setAttribute('data-sidebar-id', sidebarContext?.name || '');
-        }
-    }, [sidebarContext?.name]);
+      // Reset only when leaving /docs
+      if (!location.pathname.startsWith('/docs')) {
+        console.log("Resetting filters...");
+        resetFilters();
+      }
+    });
+  }, [history, resetFilters]);
 
-    return (
-        <>
-            {shouldRenderSidebarDesktop && <DocSidebarDesktopMemo {...props} />}
-            {shouldRenderSidebarMobile && <DocSidebarMobileMemo {...props} shouldShowFilters={shouldShowFilters} />}
-        </>
-    );
+
+  const shouldRenderSidebarDesktop = windowSize === 'desktop' || windowSize === 'ssr';
+  const shouldRenderSidebarMobile = windowSize === 'mobile';
+
+  useEffect(() => {
+      if (typeof document !== 'undefined') {
+          document.body.setAttribute('data-sidebar-id', sidebarContext?.name || '');
+      }
+  }, [sidebarContext?.name]);
+
+  return (
+      <>
+          {shouldRenderSidebarDesktop && <DocSidebarDesktopMemo {...props} />}
+          {shouldRenderSidebarMobile && <DocSidebarMobileMemo {...props} shouldShowFilters={shouldShowFilters} />}
+      </>
+  );
 }


### PR DESCRIPTION
## What reference architecture does this PR apply to?
This PR resets the filters when leaving the docs page, fixing the filtering behavior. In addition, I adjusted the carousel logos for tablet view to prevent them from displaying in two rows.

## Who should review your contribution? (Use @mention)
@cernus76 

## Checklist before submitting
- [ ] My commits are only for the reference architecture mentioned above.
- [ ] I have followed the folder structure in the [main README](../README.md)
