### PR TITLE
Fix link to Joule Studio's Agent Builder documentation

### DIFF
--- a/docs/ref-arch/RA0005/5-ai-agents/readme.md
+++ b/docs/ref-arch/RA0005/5-ai-agents/readme.md
@@ -54,7 +54,7 @@ They are designed for rapid development through configuration rather than coding
 - **Enterprise Integration**: Seamless connection via REST/OData APIs to SAP products, BTP services, and third-party applications.
 - **Secure & Scalable**: Built on top of Generative AI Hub with anonymization, metering and role-based security.
 
-For more details on leveraging AI Agents within Joule Studio’s Agent Builder, see [Extend Joule with Joule Studio](../../RA0024/readme.md).
+For more details on leveraging AI Agents within Joule Studio’s Agent Builder, see [Extend Joule with Joule Studio](../../RA0024/3-extend-joule-with-joule-studio/readme.md).
 
 ### Code-Based Agents ###
 


### PR DESCRIPTION
Updated the link for more details on AI Agents in Joule Studio.

## What reference architecture does this PR apply to?
RA0005

## Who should review your contribution? (Use @mention)
@vedant-aero-ml 

## Checklist before submitting
- [X] My commits are only for the reference architecture mentioned above.
- [X] I have followed the folder structure in the [main README](../README.md)
