### PR TITLE
docs: update Jim Rapp's title in blog authors

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,6 +1,6 @@
 jmsrpp:
   name: Jim Rapp
-  title: Chief Architect
+  title: Head of Architecture
   url: https://github.com/jmsrpp
   image_url: https://github.com/jmsrpp.png
   page: true


### PR DESCRIPTION
## Summary
- Updated Jim Rapp's title from "Chief Architect" to "Head of Architecture" in blog/authors.yml

## Changes
- Single line change in blog/authors.yml to reflect current organizational structure

## Testing Done
- [x] Verified file format is correct
- [x] No other files modified