### PR TITLE
Display The Category Path In Tags Page

### DIFF
--- a/src/plugins/tags-generator/index.js
+++ b/src/plugins/tags-generator/index.js
@@ -18,9 +18,8 @@ module.exports = function (context, options) {
 
       const docIdToTags = {};
       let sidebarContext = null;
-      let communitySidebarContext = null;
 
-     
+
       const defaultDocsInstance = docsPluginContent['default'];
 
       if (defaultDocsInstance && defaultDocsInstance.loadedVersions) {
@@ -33,30 +32,11 @@ module.exports = function (context, options) {
           });
         });
 
-        // Capture sidebar context from the loaded versions (current/default)
+        // Capture sidebar context from the loaded versions (includes all sidebars)
         if (defaultDocsInstance.loadedVersions.length > 0) {
           const currentVersion = defaultDocsInstance.loadedVersions[0];
           if (currentVersion.sidebars) {
             sidebarContext = currentVersion.sidebars;
-            // Only log in development mode
-            if (process.env.NODE_ENV === 'development') {
-              console.log('✅ Tags plugin captured sidebar context at build time:', Object.keys(sidebarContext));
-            }
-          }
-        }
-      }
-
-      // Capture community sidebar context
-      const communityDocsInstance = docsPluginContent['community'];
-      if (communityDocsInstance && communityDocsInstance.loadedVersions) {
-        if (communityDocsInstance.loadedVersions.length > 0) {
-          const communityVersion = communityDocsInstance.loadedVersions[0];
-          if (communityVersion.sidebars) {
-            communitySidebarContext = communityVersion.sidebars;
-            // Only log in development mode
-            if (process.env.NODE_ENV === 'development') {
-              console.log('✅ Tags plugin captured community sidebar context at build time:', Object.keys(communitySidebarContext));
-            }
           }
         }
       }
@@ -64,12 +44,7 @@ module.exports = function (context, options) {
       setGlobalData({
         docIdToTags,
         sidebarContext,
-        communitySidebarContext,
       });
-      // Only log in development mode
-      if (process.env.NODE_ENV === 'development') {
-        console.log('✅ Tags plugin loaded successfully and processed docs with sidebar context.');
-      }
     },
   };
 };

--- a/src/theme/DocTagDocListPage/index.tsx
+++ b/src/theme/DocTagDocListPage/index.tsx
@@ -8,23 +8,32 @@ import useGlobalData from '@docusaurus/useGlobalData';
 
 type Props = WrapperProps<typeof DocTagDocListPageType>;
 
-interface SidebarContext {
-  refarchSidebar?: unknown;
+interface SidebarItem {
+  id?: string;
+  label: string;
+  type: 'doc' | 'category';
+  link?: { id: string; };
+  items?: SidebarItem[];
 }
 
-interface CommunitySidebarContext {
-  communitySidebar?: unknown;
+interface SidebarContext {
+  refarchSidebar?: SidebarItem[];
+  communitySidebar?: SidebarItem[];
+  goldenPathSidebar?: SidebarItem[];
 }
 
 interface TagsPluginData {
   default?: {
     sidebarContext?: SidebarContext;
-    communitySidebarContext?: CommunitySidebarContext;
   };
 }
 
-interface TagItem {
-  labels?: string[];
+interface TagItemWithLabels {
+  id: string;
+  title: string;
+  description?: string;
+  permalink: string;
+  labels?: string[] | null;
 }
 
 export default function DocTagDocListPageWrapper(props: Props): ReactNode {
@@ -33,35 +42,60 @@ export default function DocTagDocListPageWrapper(props: Props): ReactNode {
     const globalData = useGlobalData();
     const tagsPluginData = globalData['docusaurus-tags-plugin'] as TagsPluginData | undefined;
     const sidebarContext = tagsPluginData?.default?.sidebarContext;
-    const communitySidebarContext = tagsPluginData?.default?.communitySidebarContext;
-    // Detect navigation source by checking the allTagsPath
-    const isNavigatingFromCommunity = props.tag?.allTagsPath?.includes('/community/') || false;
 
     let updatedProps = props;
-    if (props.tag?.items) {
-      let updatedTagItems: typeof props.tag.items = [];
-      // Navigated from Docs section
-      if (!isNavigatingFromCommunity && sidebarContext?.refarchSidebar) {
-        updatedTagItems = createTagSidebarMapping(props.tag.items, sidebarContext.refarchSidebar);
-      }
-      // Navigated from Community section
-      else if (isNavigatingFromCommunity && communitySidebarContext?.communitySidebar) {
-        updatedTagItems = createTagSidebarMapping(props.tag.items, communitySidebarContext.communitySidebar);
-      }
+    if (props.tag?.items && sidebarContext) {
+      // Maps ID prefix to sidebar key
+      const sidebarMapping: Record<string, keyof SidebarContext> = {
+        'community/': 'communitySidebar',
+        'ref-arch/': 'refarchSidebar',
+        'golden-path/': 'goldenPathSidebar',
+      };
 
+      // Process each item individually since a tag page may contain items from multiple sections
+      const updatedTagItems: TagItemWithLabels[] = props.tag.items.map((item) => {
+        // Find which sidebar to use for this specific item
+        let targetSidebar: SidebarItem[] | undefined;
+        for (const [prefix, sidebarKey] of Object.entries(sidebarMapping)) {
+          if (item.id.startsWith(prefix)) {
+            targetSidebar = sidebarContext[sidebarKey];
+            break;
+          }
+        }
+
+        // If no sidebar found, return item as-is
+        if (!targetSidebar) {
+          return {
+            id: item.id,
+            title: item.title,
+            description: item.description,
+            permalink: item.permalink,
+            labels: null
+          };
+        }
+
+        // Map this single item with its appropriate sidebar
+        const mappedItems = createTagSidebarMapping([item], targetSidebar);
+        return mappedItems[0];
+      });
+
+      // Update props with items that have labels
       if (updatedTagItems.length > 0) {
         updatedProps = {
           ...props,
           tag: {
             ...props.tag,
-            items: updatedTagItems
+            items: updatedTagItems as typeof props.tag.items
           }
         };
       }
     }
 
     // use custom component when labels are available, otherwise use original
-    const hasLabels = updatedProps.tag?.items?.some((item: TagItem) => item.labels && item.labels.length > 0);
+    const hasLabels = updatedProps.tag?.items?.some((item) => {
+      const typedItem = item as unknown as TagItemWithLabels;
+      return typedItem.labels && typedItem.labels.length > 0;
+    });
 
     return (
       <>


### PR DESCRIPTION
Restructuring the docs folder affected the tags page paths, so we needed a new logic to display the category path for all sidebars.