### PR TITLE
 Fix Docker export path resolution in _export-drawios.js

### DIFF
--- a/src/_scripts/_export-drawios.js
+++ b/src/_scripts/_export-drawios.js
@@ -88,9 +88,8 @@ function exportAllDrawios() {
                 let cmd = DRAWIO_CLI_BINARY;
                 let args = ['--export', '--embed-svg-images', '--svg-theme', 'light', '--output'];
                 if (DOCKER) {
-                    const d = 'docs/';
-                    const relativeOut = d + out.split(d)[1];
-                    const relativeInput = d + input.split(d)[1];
+                    const relativeOut = out.slice(ROOT.length + 1);
+                    const relativeInput = input.slice(ROOT.length + 1);
                     cmd = 'docker';
                     args = ['run', '-w', '/data', '-v', `${ROOT}:/data`, 'rlespinasse/drawio-desktop-headless'].concat(args);
                     args.push(relativeOut, relativeInput);


### PR DESCRIPTION
## Changes
- Fixed a bug where SVG export failed for new drawio files under Docker (used in gh actions). The old code used
  split('docs/') to compute relative paths for the Docker volume mount, which broke when docs/ didn't appear exactly
  once in the absolute path. Replaced with slice(ROOT.length + 1) to reliably strip the root prefix.

### What
  
  - Fixed Docker SVG export failing for new drawio files in CI
  - Added optional CLI folder filter for local development

 ### Why

  The export script uses Docker in CI to convert .drawio files to SVGs. The Docker branch computed relative paths using
  split('docs/'), which breaks when docs/ doesn't appear exactly once in the absolute runner path — passing
  docs/undefined to the Docker CLI and silently failing the export.

  4 out of 5 new RA0030 drawio files failed for this reason. The 5th (3-posting) succeeded only because it had a cache
  hit from a previous run and never entered the broken code path.

 ### How

  Replaced the fragile string split with a slice anchored to ROOT:

  // Before
  const relativeOut = 'docs/' + out.split('docs/')[1];

  // After
  const relativeOut = out.slice(ROOT.length + 1);

## Who should review your contribution? (Use @mention)
@cernus76 

## Checklist before submitting
- [ ] My commits are only for the reference architecture mentioned above.
- [ ] I have followed the folder structure in the [main README](../README.md)
