### PR TITLE
Bug 3: invalid tag state no longer persists after selecting a valid tag

### DIFF
--- a/src/components/MetaFormDialog/index.tsx
+++ b/src/components/MetaFormDialog/index.tsx
@@ -58,6 +58,7 @@ export default React.memo(function MetadataFormDialog({
     const { user, token } = useAuth();
 
     const [contributorSearchQuery, setContributorSearchQuery] = useState('');
+    const [tagSearchQuery, setTagSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState<GitHubUser[]>([]);
     const [isSearching, setIsSearching] = useState(false);
     const [userAvatars, setUserAvatars] = useState<Record<string, string>>({});
@@ -83,6 +84,7 @@ export default React.memo(function MetadataFormDialog({
 
     const abortControllerRef = useRef<AbortController | null>(null);
     const multiComboRef = useRef<HTMLElement | null>(null);
+    const tagsComboRef = useRef<HTMLElement | null>(null);
 
     const fetchUsers = useCallback(async () => {
         if (abortControllerRef.current) {
@@ -190,6 +192,16 @@ export default React.memo(function MetadataFormDialog({
             })
             .filter((key): key is string => !!key);
         onDataChange({ tags: selectedKeys });
+        // After a selection, UI5 restores whatever was typed (e.g. an invalid "kjhg")
+        // back into the input and leaves the red "Negative" value state in place. Clear
+        // the typed text via the controlled value (React re-renders after UI5's restore)
+        // and reset the value state directly on the element, so a correctly-selected tag
+        // never appears invalid.
+        setTagSearchQuery('');
+        const tagsCombo = tagsComboRef.current as (HTMLElement & { valueState: string }) | null;
+        if (tagsCombo) {
+            tagsCombo.valueState = 'None';
+        }
     };
 
     const handleContributorInput = (event: InputEvent) => {
@@ -323,7 +335,13 @@ export default React.memo(function MetadataFormDialog({
                 </FormItem>
 
                 <FormItem labelContent={<Label required>Tags</Label>}>
-                    <MultiComboBox onSelectionChange={handleTagUpdate} placeholder="Select at least one tag...">
+                    <MultiComboBox
+                        ref={tagsComboRef}
+                        value={tagSearchQuery}
+                        onInput={(e: InputEvent) => setTagSearchQuery(e.target.value || '')}
+                        onSelectionChange={handleTagUpdate}
+                        placeholder="Select at least one tag..."
+                    >
                         {availableTags.map((tag) => (
                             <MultiComboBoxItem
                                 key={tag.key}


### PR DESCRIPTION
## Summary
Fixes an invalid-tag validation glitch in the **Create / Edit Reference Architecture** form dialog (`MetaFormDialog`). Ports the fix already reviewed and tested in the Quick Start repo to `architecture-center` (follow-up to #996).

## Problem
In the **Tags** field, typing a string that doesn't match any tag turns the field red (`Negative` value state). If you then select a valid tag from the dropdown, UI5 restored the typed text back into the input and left the red `Negative` state in place — so a correctly-selected tag still appeared invalid.

## Fix
Made the Tags `MultiComboBox` a **controlled** component (`ref` + `value` + `onInput`). In `handleTagUpdate`, after committing the selected tags we now:
- clear the typed text via `setTagSearchQuery('')`, and
- reset the element's value state with `tagsCombo.valueState = 'None'`.

This mirrors the existing pattern already used by the Contributors field.

## Testing
- Ran the app locally against the backend.
- Typed an invalid string in **Tags** (field turns red) → selected a valid tag from the dropdown → the red `Negative` state and leftover text now clear correctly.
- No other fields or behaviors affected.

## Scope
- Single file changed: `src/components/MetaFormDialog/index.tsx` (+19 / −1). No other files touched.
