### PR TITLE
Updates fm cap app

### DIFF
--- a/docs/ref-arch/RA0032/1-integration-with-palantir/readme.md
+++ b/docs/ref-arch/RA0032/1-integration-with-palantir/readme.md
@@ -1,16 +1,18 @@
 ---
-id: 968090
+id: '968090'
 slug: /ref-arch/968090
 sidebar_position: 1
 title: Integration with Palantir
-description: Explore how SAP Data Accelerator provides SAP customers using Palantir Foundry with a high-throughput, governed path to securely connect SAP data to Foundry.
-sidebar_label: Integration with Palantir
+description: >-
+  Explore how SAP Data Accelerator provides SAP customers using Palantir Foundry
+  with a high-throughput, governed path to securely connect SAP data to Foundry.
 keywords:
   - sap
   - palantir
   - data integration
   - analytics
   - data accelerator
+sidebar_label: Integration with Palantir
 image: img/ac-soc-med.png
 tags:
   - ref-arch
@@ -23,6 +25,7 @@ draft: false
 unlisted: false
 contributors:
   - s-krishnamoorthy
+discussion: 
 last_update:
   author: s-krishnamoorthy
   date: 2026-08-17

--- a/docs/ref-arch/RA0032/readme.md
+++ b/docs/ref-arch/RA0032/readme.md
@@ -1,10 +1,12 @@
 ---
-id: 6972e8
-slug: /ref-arch/6972e8
+id: a22904
+slug: /ref-arch/a22904
 sidebar_position: 160
 title: SAP Data Accelerator
-description: SAP Data Accelerator (DA) is a cloud-native, SAP-managed service that provides authorized external partners with governed, near-real-time access to SAP on-premises and private cloud business data.
-sidebar_label: SAP Data Accelerator
+description: >-
+  SAP Data Accelerator (DA) is a cloud-native, SAP-managed service that provides
+  authorized external partners with governed, near-real-time access to SAP
+  on-premises and private cloud business data.
 keywords:
   - sap
   - data accelerator
@@ -12,6 +14,7 @@ keywords:
   - analytics
   - palantir
   - data and analytics
+sidebar_label: SAP Data Accelerator
 image: img/ac-soc-med.png
 tags:
   - ref-arch
@@ -24,6 +27,7 @@ draft: false
 unlisted: false
 contributors:
   - s-krishnamoorthy
+discussion: 
 last_update:
   author: s-krishnamoorthy
   date: 2026-08-17

--- a/docs/ref-arch/RA0033/readme.md
+++ b/docs/ref-arch/RA0033/readme.md
@@ -2,8 +2,8 @@
 id: 2ecb7e
 slug: /ref-arch/2ecb7e
 sidebar_position: 150
-title: 'HANA AI Toolkit - Local MCP Server'
-description: 'Local MCP Server for Generative AI Toolkit for SAP HANA Cloud'
+title: HANA AI Toolkit - Local MCP Server
+description: Local MCP Server for Generative AI Toolkit for SAP HANA Cloud
 keywords:
   - sap
   - hana
@@ -13,22 +13,23 @@ keywords:
   - model context protocol
   - ai agents
   - generative ai
-sidebar_label: 'HANA AI Toolkit - Local MCP Server'
+sidebar_label: HANA AI Toolkit - Local MCP Server
 image: img/ac-soc-med.png
+tags:
+  - agents
+  - data
 hide_table_of_contents: false
 hide_title: false
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 draft: false
 unlisted: false
-tags:
-  - agents
-  - data
 contributors:
   - raymondyao
+discussion: 
 last_update:
-  date: 2026-06-15
   author: raymondyao
+  date: 2026-06-15
 ---
 
 The **HANAMLToolkit local MCP server** is a Model Context Protocol (MCP) endpoint that turns the [hana-ml](https://pypi.org/project/hana-ml/) Python library into a set of governed tools that AI agents — Joule, Claude Desktop, IDE-side copilots, custom LangChain/LangGraph agents — can invoke against an SAP HANA Cloud instance. The server is shipped as part of the [hana-ai](https://pypi.org/project/hana-ai/) toolkit, runs in-process next to the agent or as a sidecar, and exposes the same tool catalog over three interchangeable transports: **stdio**, **SSE**, and **streamable HTTP**.

--- a/src/constant/config-plugin-client-redirects.ts
+++ b/src/constant/config-plugin-client-redirects.ts
@@ -511,5 +511,10 @@ export const configRedirects = {
             from: '/docs/ref-arch/08N_yhbT',
             to: '/docs/ref-arch/458ff4',
         },
+        // RA0032
+        {
+            from: '/docs/ref-arch/6972e8',
+            to: '/docs/ref-arch/a22904',
+        },
     ],
 };


### PR DESCRIPTION
Mostly just formatting. The id 6972e8 needed to be changed to a different id because otherwise gray-matter/js-yaml, which parses the incoming frontmatter in the CAP app, would interpret it as scientific notation and try to store it mistakenly as the number 697200000000


## What reference architecture does this PR apply to?


## Who should review your contribution? (Use @mention)
@cernus76 

## Checklist before submitting
- [ ] My commits are only for the reference architecture mentioned above.
- [ ] I have followed the folder structure in the [main README](../README.md)
